### PR TITLE
getFileContents action: Fail gracefully if file does not exist

### DIFF
--- a/actions/getFileContents/index.js
+++ b/actions/getFileContents/index.js
@@ -15,6 +15,12 @@ module.exports = async (context, opts) => {
 
   const tree = await context.github.gitdata.getTree(context.repo({ tree_sha: sha, recursive: 1 }))
   const file = tree.data.tree.find(file => file.path === opts.filename)
-  const blob64 = await context.github.gitdata.getBlob(context.repo({ file_sha: file.sha }))
-  return Buffer.from(blob64.data.content, 'base64').toString()
+
+  try {
+    const blob64 = await context.github.gitdata.getBlob(context.repo({ file_sha: file.sha }))
+    return Buffer.from(blob64.data.content, 'base64').toString()
+  } catch (err) {
+    // Return false if the file does not exist so we can react with `gate`
+    return false
+  }
 }

--- a/actions/getFileContents/index.test.js
+++ b/actions/getFileContents/index.test.js
@@ -29,4 +29,10 @@ describe('getFileContents', () => {
     expect(context.github.gitdata.getTree.mock.calls).toMatchSnapshot()
     expect(ret).toMatchSnapshot()
   })
+
+  it('returns false if the content does not exist', async () => {
+    context.github.gitdata.getBlob.mockImplementationOnce(() => { throw new Error(404) })
+    const ret = await getFileContents(context, { filename: 'filename' })
+    expect(ret).toBe(false)
+  })
 })


### PR DESCRIPTION
### Why?

If a course author calls `getFileContents`, but the file doesn't exist, the action errors out. We therefore can't use it to `gate` information.

### What is being changed?

Basically wrapped the `getBlob` call in a `try`/`catch`.

---

If adding or updating an action, please verify that you have:
- [x] Added or updated tests, and verified they pass by executing `npm test`
- [x] Added or updated code comments, if applicable
- [x] Generated up-to-date documentation by executing `npm run doc`, if a schema was added or updated
