### PR TITLE
Add version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <h3 align="center">Learning Lab Components</h3>
 <p align="center">Open sourced components from <a href="https://lab.github.com/">GitHub Learning Lab</a></p>
+<p align="center"><a href="https://github.com/github/learning-lab-components/packages/11396"><img src="https://img.shields.io/github/release/github/learning-lab-components.svg?label=GPR&logo=github" alt="GitHub Package Registry version" /></a></p>
 
 ## Overview
 


### PR DESCRIPTION
### Why?

Closes #55

### What is being changed?

Adding a version badge to the README, which looks basically like this:

![GPR label with GitHub mark logo](https://user-images.githubusercontent.com/417751/61496698-afb18480-a982-11e9-8429-34afb22ffa93.png)
