### PR TITLE
Switch codecov badge service in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
   <a href="https://github.com/github/learning-lab-components/packages/11396"><img src="https://img.shields.io/github/release/github/learning-lab-components.svg?label=GPR&logo=github" alt="GitHub Package Registry version" /></a>
   <a href="https://github.com/github/learning-lab-components/actions"><img src="https://action-badges.now.sh/github/learning-lab-components" alt="Build Status" /></a>
-  <a href="https://codecov.io/gh/github/learning-lab-components"><img src="https://badgen.now.sh/codecov/c/github/github/learning-lab-components" alt="Code Coverage" /></a>
+  <a href="https://codecov.io/gh/github/learning-lab-components"><img src="https://img.shields.io/codecov/c/gh/github/learning-lab-components.svg?label=codecov&logo=codecov&logoColor=FFFFFF" alt="Code Coverage" /></a>
 </p>
 
 ## Overview


### PR DESCRIPTION
### Why?

The codecov badge added by PR #34 from badgen.net appears to have a 3-hour cache time for proxies (like GitHub's camo cache for images in Markdown files 😢) via the `s-maxage` value in its `Cache-Control` HTTP response header.

The equivalent badge from the shields.io only has a cache time of 2 minutes via the `max-age` value in its `Cache-Control` HTTP response header, which is much more useful for badges.

### What is being changed?

Switch service for the codecov badge in README. 🛡 