### PR TITLE
Add DavidDM dependency status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
   <a href="https://github.com/github/learning-lab-components/packages/11396"><img src="https://img.shields.io/github/release/github/learning-lab-components.svg?label=GPR&logo=github" alt="GitHub Package Registry version" /></a>
   <a href="https://github.com/github/learning-lab-components/actions"><img src="https://action-badges.now.sh/github/learning-lab-components" alt="Build Status" /></a>
   <a href="https://codecov.io/gh/github/learning-lab-components"><img src="https://img.shields.io/codecov/c/gh/github/learning-lab-components.svg?label=codecov&logo=codecov&logoColor=FFFFFF" alt="Code Coverage" /></a>
+  <a href="https://david-dm.org/github/learning-lab-components"><img src="https://img.shields.io/david/github/learning-lab-components.svg" alt="Dependencies Status" /></a>
+  <a href="https://david-dm.org/github/learning-lab-components?type=dev"><img src="https://img.shields.io/david/dev/github/learning-lab-components.svg?label=devDependencies" alt="devDependencies Status" /></a>
 </p>
 
 ## Overview


### PR DESCRIPTION
### Why?

To help us keep track of our dependencies' currentness. Combined with Dependabot, hopefully these will never get too outdated for long. 🤞 

### What is being changed?

Add currentness status badges for our package's `dependencies` and `devDependencies` to the README.