### PR TITLE
Add Dependabot enablement badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   <a href="https://github.com/github/learning-lab-components/packages/11396"><img src="https://img.shields.io/github/release/github/learning-lab-components.svg?label=GPR&logo=github" alt="GitHub Package Registry version" /></a>
   <a href="https://github.com/github/learning-lab-components/actions"><img src="https://action-badges.now.sh/github/learning-lab-components" alt="Build Status" /></a>
   <a href="https://codecov.io/gh/github/learning-lab-components"><img src="https://img.shields.io/codecov/c/gh/github/learning-lab-components.svg?label=codecov&logo=codecov&logoColor=FFFFFF" alt="Code Coverage" /></a>
+  <img src="https://api.dependabot.com/badges/status?host=github&repo=github/learning-lab-components" alt="Dependabot Enablement" />
 </p>
 
 ## Overview


### PR DESCRIPTION
### Why?

To help bolster contributor and consumer confidence in our dependency management, this adds proof that our repo is enabled for Dependabot support. 🤖 

### What is being changed?

Add a Dependabot badge to the README