### PR TITLE
Upgrade Joi usage to 16.x compliance

### DIFF
--- a/actions/assignRegistrant/schema.js
+++ b/actions/assignRegistrant/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   issue: Joi.alternatives(Joi.string(), Joi.number())

--- a/actions/closeIssue/schema.js
+++ b/actions/closeIssue/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   issue: Joi.alternatives(Joi.string(), Joi.number())

--- a/actions/createFile/schema.js
+++ b/actions/createFile/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 const data = require('../../schemas/data')
 
 module.exports = Joi.object({

--- a/actions/createIssue/schema.js
+++ b/actions/createIssue/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 const data = require('../../schemas/data')
 
 module.exports = Joi.object({

--- a/actions/createLabel/schema.js
+++ b/actions/createLabel/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   name: Joi.string()

--- a/actions/createProjectBoard/schema.js
+++ b/actions/createProjectBoard/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   name: Joi.string()

--- a/actions/createPullRequest/schema.js
+++ b/actions/createPullRequest/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 const data = require('../../schemas/data')
 
 module.exports = Joi.object({

--- a/actions/createPullRequestComment/schema.js
+++ b/actions/createPullRequestComment/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 const data = require('../../schemas/data')
 
 module.exports = Joi.object({

--- a/actions/createReview/schema.js
+++ b/actions/createReview/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 const data = require('../../schemas/data')
 
 module.exports = Joi.object({

--- a/actions/createStatus/schema.js
+++ b/actions/createStatus/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 const gate = require('../gate/schema')
 
 const state = Joi.object({

--- a/actions/deleteBranch/schema.js
+++ b/actions/deleteBranch/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   branch: Joi.string()

--- a/actions/findInTree/schema.js
+++ b/actions/findInTree/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   path: Joi.string()

--- a/actions/gate/schema.js
+++ b/actions/gate/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 const operations = require('./operations')
 
 const gate = Joi.object({
@@ -8,7 +8,7 @@ const gate = Joi.object({
   operator: Joi.string()
     .meta({ label: 'Operator' })
     .description('The conditional operator to use when evaluating the gate.')
-    .valid(Object.keys(operations)),
+    .valid(...Object.keys(operations)),
   right: Joi.alternatives(Joi.number(), Joi.string(), Joi.boolean())
     .meta({ label: 'Right' })
     .description('The right side of the `if`.')

--- a/actions/getFileContents/schema.js
+++ b/actions/getFileContents/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   filename: Joi.string()

--- a/actions/getIssue/schema.js
+++ b/actions/getIssue/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   issue: Joi.alternatives(Joi.string(), Joi.number())

--- a/actions/getPullRequest/schema.js
+++ b/actions/getPullRequest/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   pullRequest: Joi.alternatives(Joi.string(), Joi.number())

--- a/actions/getTree/schema.js
+++ b/actions/getTree/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   sha: Joi.string()

--- a/actions/htmlContainsTag/schema.js
+++ b/actions/htmlContainsTag/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   html: Joi.string()

--- a/actions/mergeBranch/schema.js
+++ b/actions/mergeBranch/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   head: Joi.string()

--- a/actions/mergePullRequest/schema.js
+++ b/actions/mergePullRequest/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   pullRequest: Joi.alternatives(Joi.number(), Joi.string())

--- a/actions/octokit/schema.js
+++ b/actions/octokit/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   method: Joi.string()

--- a/actions/removeBranchProtection/schema.js
+++ b/actions/removeBranchProtection/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   branch: Joi.string()

--- a/actions/requestReviewFromRegistrant/schema.js
+++ b/actions/requestReviewFromRegistrant/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   pullRequest: Joi.alternatives(Joi.number(), Joi.string())

--- a/actions/respond/schema.js
+++ b/actions/respond/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 const data = require('../../schemas/data')
 
 module.exports = Joi.object({

--- a/actions/updateBranchProtection/schema.js
+++ b/actions/updateBranchProtection/schema.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   branch: Joi.string()

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,22 +172,26 @@
     "@hapi/address": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
-      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==",
+      "dev": true
     },
     "@hapi/bourne": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
-      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "dev": true
     },
     "@hapi/hoek": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-7.2.1.tgz",
-      "integrity": "sha512-X6YzLoU+VvZwUNe0VFJV/r4IiFHf61/6VItdnKjlay+YS/5qoczO3u/7wyTj2NtaOZHlFJBndNkfZ2Ag2XxCsg=="
+      "integrity": "sha512-X6YzLoU+VvZwUNe0VFJV/r4IiFHf61/6VItdnKjlay+YS/5qoczO3u/7wyTj2NtaOZHlFJBndNkfZ2Ag2XxCsg==",
+      "dev": true
     },
     "@hapi/joi": {
       "version": "16.0.0-rc2",
       "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.0.0-rc2.tgz",
       "integrity": "sha512-lrErR1oaXT/ugFLfoQkqEytJuLvXG0aRXV83qVfPjVbgyQBG0HnSG7tSIiB+OlkJYDHngE29cqNOq/hcski6hQ==",
+      "dev": true,
       "requires": {
         "@hapi/address": "2.x.x",
         "@hapi/bourne": "1.x.x",
@@ -199,12 +203,14 @@
     "@hapi/marker": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
-      "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
+      "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA==",
+      "dev": true
     },
     "@hapi/topo": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz",
       "integrity": "sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "8.x.x"
       },
@@ -212,7 +218,8 @@
         "@hapi/hoek": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.1.0.tgz",
-          "integrity": "sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA=="
+          "integrity": "sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA==",
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -169,6 +169,53 @@
         "minimist": "^1.2.0"
       }
     },
+    "@hapi/address": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
+      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+    },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
+    },
+    "@hapi/hoek": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-7.2.1.tgz",
+      "integrity": "sha512-X6YzLoU+VvZwUNe0VFJV/r4IiFHf61/6VItdnKjlay+YS/5qoczO3u/7wyTj2NtaOZHlFJBndNkfZ2Ag2XxCsg=="
+    },
+    "@hapi/joi": {
+      "version": "16.0.0-rc2",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.0.0-rc2.tgz",
+      "integrity": "sha512-lrErR1oaXT/ugFLfoQkqEytJuLvXG0aRXV83qVfPjVbgyQBG0HnSG7tSIiB+OlkJYDHngE29cqNOq/hcski6hQ==",
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "7.x.x",
+        "@hapi/marker": "1.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/marker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
+      "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
+    },
+    "@hapi/topo": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz",
+      "integrity": "sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==",
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.1.0.tgz",
+          "integrity": "sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA=="
+        }
+      }
+    },
     "@jest/console": {
       "version": "24.7.1",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
@@ -3553,11 +3600,6 @@
         }
       }
     },
-    "hoek": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
-    },
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -3971,14 +4013,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
-    },
-    "isemail": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-      "requires": {
-        "punycode": "2.x.x"
-      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -4500,16 +4534,6 @@
             "has-flag": "^3.0.0"
           }
         }
-      }
-    },
-    "joi": {
-      "version": "14.3.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
-      "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
-      "requires": {
-        "hoek": "6.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
       }
     },
     "js-tokens": {
@@ -5926,7 +5950,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "qs": {
       "version": "6.5.2",
@@ -6989,14 +7014,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
-    },
-    "topo": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
-      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
-      "requires": {
-        "hoek": "6.x.x"
-      }
     },
     "tough-cookie": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -46,13 +46,16 @@
     "test": "standard && jest --coverage"
   },
   "dependencies": {
-    "@hapi/joi": "^16.0.0-rc2",
     "@octokit/rest": "^15.18.1",
     "get-value": "^3.0.1",
     "has": "^1.0.3",
     "htmlparser2": "^3.10.1"
   },
+  "peerDependencies": {
+    "@hapi/joi": "^16.0.0-rc2"
+  },
   "devDependencies": {
+    "@hapi/joi": "^16.0.0-rc2",
     "enquirer": "^2.3.1",
     "jest": "^24.8.0",
     "js-yaml": "^3.13.1",

--- a/package.json
+++ b/package.json
@@ -46,11 +46,11 @@
     "test": "standard && jest --coverage"
   },
   "dependencies": {
+    "@hapi/joi": "^16.0.0-rc2",
     "@octokit/rest": "^15.18.1",
     "get-value": "^3.0.1",
     "has": "^1.0.3",
-    "htmlparser2": "^3.10.1",
-    "joi": "^14.3.1"
+    "htmlparser2": "^3.10.1"
   },
   "devDependencies": {
     "enquirer": "^2.3.1",

--- a/schemas/data.js
+++ b/schemas/data.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 module.exports = Joi.object()
   .meta({ label: 'Data' })

--- a/script/create-new-action.js
+++ b/script/create-new-action.js
@@ -51,7 +51,7 @@ async function getActionMetadata () {
  * @returns {string} The "schema.js" contents.
  */
 function createSchema ({ name, description }) {
-  const schemaContents = `const Joi = require('joi')
+  const schemaContents = `const Joi = require('@hapi/joi')
 const data = require('../../schemas/data')
 
 module.exports = Joi.object({

--- a/script/generate-action-docs.js
+++ b/script/generate-action-docs.js
@@ -55,10 +55,12 @@ function mapChildrenToRows (children) {
 function mapExamples (examples, key) {
   const blocks = examples
     .map(obj => {
+      const [value, options] = obj
+
       // Add the `type` property, because including it in the example wouldn't be valid for the schema
-      const yaml = jsYaml.safeDump({ type: key, ...obj.value })
+      const yaml = jsYaml.safeDump({ type: key, ...value })
       // Include the context if it exists
-      const prefix = obj.options && obj.options.context ? `${obj.options.context}\n\n` : ''
+      const prefix = options && options.context ? `${options.context}\n\n` : ''
       return `${prefix}\`\`\`yaml\n${yaml}\`\`\``
     })
     .join('\n\n')

--- a/tests/actions/index.test.js
+++ b/tests/actions/index.test.js
@@ -55,7 +55,6 @@ ${actionNames.map(name => `- [${name}](./${name})`).join('\n')}
     it('has a "schema" property', () => {
       expect(action).toHaveProperty('schema')
       expect(action.schema).toBeTruthy()
-      expect(action.schema.isJoi).toBe(true)
     })
 
     describe('has a schema which', () => {
@@ -76,16 +75,18 @@ ${actionNames.map(name => `- [${name}](./${name})`).join('\n')}
         const hasMoreThanOneExample = schema.examples.length > 1
 
         for (const example of schema.examples) {
-          expect(isPlainObject(example)).toBe(true)
-          expect(example).toHaveProperty('value')
-          expect(isPlainObject(example.value)).toBe(true)
+          expect(Array.isArray(example)).toBe(true)
+          expect(example.length).toBeGreaterThanOrEqual(1)
+          expect(example.length).toBeLessThanOrEqual(2)
+
+          const [value, options] = example
+          expect(isPlainObject(value)).toBe(true)
 
           if (hasMoreThanOneExample) {
-            expect(example).toHaveProperty('options')
-            expect(isPlainObject(example.options)).toBe(true)
-            expect(example.options).toHaveProperty('context')
-            expect(typeof example.options.context).toBe('string')
-            expect(example.options.context.length).toBeGreaterThan(0)
+            expect(isPlainObject(options)).toBe(true)
+            expect(options).toHaveProperty('context')
+            expect(typeof options.context).toBe('string')
+            expect(options.context.length).toBeGreaterThan(0)
           }
         }
       })


### PR DESCRIPTION
### Why?

GitHub Learning Lab would like to take advantage of a few upcoming features in the next version of Joi for some more advanced schema validation.

Joi `16.x` is currently in a pre-release version but will hopefully be released soon as its [`16.0.0` Milestone](https://github.com/hapijs/joi/milestone/138) nears completion... currently 166 closed vs. 4 open issues: 97%.

Closes #68 

### What is being changed?

- Upgrade to use the prerelease version of the next `@hapi/joi@16.x`
- Demote `@hapi/joi` usage to be a peerDependency so it will utilize Learning Lab's version
- Fix the action documentation generator script to work with `@hapi/joi@16.x`
