### PR TITLE
Update Joi.alternatives usage for 16.x compatibility

### DIFF
--- a/actions/assignRegistrant/schema.js
+++ b/actions/assignRegistrant/schema.js
@@ -1,7 +1,7 @@
 const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
-  issue: Joi.alternatives(Joi.string(), Joi.number())
+  issue: Joi.alternatives().try([Joi.number(), Joi.string()])
     .meta({ label: 'Issue' })
     .description('The number or title of the issue to assign.')
 })

--- a/actions/closeIssue/schema.js
+++ b/actions/closeIssue/schema.js
@@ -1,7 +1,7 @@
 const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
-  issue: Joi.alternatives(Joi.string(), Joi.number())
+  issue: Joi.alternatives().try([Joi.number(), Joi.string()])
     .meta({ label: 'Issue' })
     .description('The number or title of the issue to close.')
 })

--- a/actions/createPullRequestComment/schema.js
+++ b/actions/createPullRequestComment/schema.js
@@ -14,7 +14,7 @@ module.exports = Joi.object({
     .meta({ label: 'Position' })
     .description('The position of the comment to be generated. This is the line number of the combined diff of the pull request.')
     .required(),
-  pullRequest: Joi.alternatives(Joi.number(), Joi.string())
+  pullRequest: Joi.alternatives().try([Joi.number(), Joi.string()])
     .meta({ label: 'Pull request' })
     .description('The title or number of the pull request. If omitted, the comment will be created on the pull request from the trigger event.'),
   data

--- a/actions/createReview/schema.js
+++ b/actions/createReview/schema.js
@@ -14,7 +14,7 @@ module.exports = Joi.object({
   number: Joi.number()
     .meta({ label: 'Number (deprecated)' })
     .description('The number of the pull request.'),
-  pullRequest: Joi.alternatives(Joi.number(), Joi.string())
+  pullRequest: Joi.alternatives().try([Joi.number(), Joi.string()])
     .meta({ label: 'Pull request' })
     .description('The title or number of the pull request. If omitted, the comment will be created on the pull request from the trigger event.'),
   data

--- a/actions/createStatus/schema.js
+++ b/actions/createStatus/schema.js
@@ -10,7 +10,11 @@ const state = Joi.object({
 })
 
 module.exports = Joi.object({
-  state: Joi.alternatives(Joi.string().valid('error', 'failure', 'pending', 'success'), gate)
+  state: Joi.alternatives()
+    .try([
+      Joi.string().valid('error', 'failure', 'pending', 'success'),
+      gate
+    ])
     .meta({ label: 'State' })
     .description('The state of the status to create.')
     .required(),

--- a/actions/gate/schema.js
+++ b/actions/gate/schema.js
@@ -2,14 +2,14 @@ const Joi = require('@hapi/joi')
 const operations = require('./operations')
 
 const gate = Joi.object({
-  left: Joi.alternatives(Joi.number(), Joi.string(), Joi.boolean())
+  left: Joi.alternatives().try([Joi.number(), Joi.string(), Joi.boolean()])
     .meta({ label: 'Left' })
     .description('The left side of the `if`. If no `operator` or `right` is present, this will be evaluated on its own.'),
   operator: Joi.string()
     .meta({ label: 'Operator' })
     .description('The conditional operator to use when evaluating the gate.')
     .valid(...Object.keys(operations)),
-  right: Joi.alternatives(Joi.number(), Joi.string(), Joi.boolean())
+  right: Joi.alternatives().try([Joi.number(), Joi.string(), Joi.boolean()])
     .meta({ label: 'Right' })
     .description('The right side of the `if`.')
 })

--- a/actions/getIssue/schema.js
+++ b/actions/getIssue/schema.js
@@ -1,7 +1,7 @@
 const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
-  issue: Joi.alternatives(Joi.string(), Joi.number())
+  issue: Joi.alternatives().try([Joi.number(), Joi.string()])
     .meta({ label: 'Issue' })
     .description('The number or title of the issue to get. This will default to the issue number from the trigger event.')
 })

--- a/actions/getPullRequest/schema.js
+++ b/actions/getPullRequest/schema.js
@@ -1,7 +1,7 @@
 const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
-  pullRequest: Joi.alternatives(Joi.string(), Joi.number())
+  pullRequest: Joi.alternatives().try([Joi.number(), Joi.string()])
     .meta({ label: 'Pull request' })
     .description('The number or title of the pull request to get. This will default to the pull request number from the trigger event.'),
   waitForMergeable: Joi.boolean()

--- a/actions/mergePullRequest/schema.js
+++ b/actions/mergePullRequest/schema.js
@@ -1,7 +1,7 @@
 const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
-  pullRequest: Joi.alternatives(Joi.number(), Joi.string())
+  pullRequest: Joi.alternatives().try([Joi.number(), Joi.string()])
     .meta({ label: 'Pull request' })
     .description('The number or title of the pull request to merge. This will default to the pull request number from the trigger event.')
 })

--- a/actions/requestReviewFromRegistrant/schema.js
+++ b/actions/requestReviewFromRegistrant/schema.js
@@ -1,7 +1,7 @@
 const Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
-  pullRequest: Joi.alternatives(Joi.number(), Joi.string())
+  pullRequest: Joi.alternatives().try([Joi.number(), Joi.string()])
     .meta({ label: 'Pull request' })
     .description('The number or title of the pull request to request a review. This will default to the pull request number from the trigger event.')
 })

--- a/actions/respond/schema.js
+++ b/actions/respond/schema.js
@@ -6,7 +6,7 @@ module.exports = Joi.object({
     .meta({ label: 'With', isResponse: true })
     .description('The name of the response file to use in the generated comment.')
     .required(),
-  issue: Joi.alternatives(Joi.number(), Joi.string())
+  issue: Joi.alternatives().try([Joi.number(), Joi.string()])
     .meta({ label: 'Issue or pull request' })
     .description('The number or title of the issue or pull request to comment on. This will default to the number from the trigger event.'),
   data


### PR DESCRIPTION
### Why?

Follow-on to issues discovered while trying to integrate #69 into GitHub Learning Lab

### What is being changed?

Joi also changed the API expectations for the `Joi.alternatives()` method. 😮 