### PR TITLE
Add a more useful link around the Dependabot badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This library contains all of the JavaScript-based bot actions that Learning Lab 
 The bot actions from the [latest release of this repository on the GitHub Package Registry](https://github.com/github/learning-lab-components/packages/11396) are used in production by GitHub Learning Lab within a Node.js environment.
 
 By making these bot actions available as an open source library, we hope to work with Learning Lab course authors to create the functionality that their courses need, and to improve the product together. You can [contribute](.github/CONTRIBUTING.md) in any of the following ways:
- - [reporting bugs](issues/new?labels=bug&template=bug_report.md) and collaborating on fixes for existing bot actions
- - [suggesting enhancements](issues/new?labels=enhancement&template=feature_request.md) for existing bot actions
- - [requesting](issues/new?labels=enhancement&template=feature_request.md) or [creating new bot actions](actions/README.md#adding-a-new-action)
+ - [reporting bugs](https://github.com/github/learning-lab-components/issues/new?labels=bug&template=bug_report.md) and collaborating on fixes for existing bot actions
+ - [suggesting enhancements](https://github.com/github/learning-lab-components/issues/new?labels=enhancement&template=feature_request.md) for existing bot actions
+ - [requesting](https://github.com/github/learning-lab-components/issues/new?labels=enhancement&template=feature_request.md) or [creating new bot actions](actions/README.md#adding-a-new-action)
 
 ![learning-lab-components](https://user-images.githubusercontent.com/417751/61059163-2f0cea00-a3be-11e9-8e70-c87d9ba54f92.png)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <a href="https://github.com/github/learning-lab-components/packages/11396"><img src="https://img.shields.io/github/release/github/learning-lab-components.svg?label=GPR&logo=github" alt="GitHub Package Registry version" /></a>
   <a href="https://github.com/github/learning-lab-components/actions"><img src="https://action-badges.now.sh/github/learning-lab-components" alt="Build Status" /></a>
   <a href="https://codecov.io/gh/github/learning-lab-components"><img src="https://img.shields.io/codecov/c/gh/github/learning-lab-components.svg?label=codecov&logo=codecov&logoColor=FFFFFF" alt="Code Coverage" /></a>
-  <img src="https://api.dependabot.com/badges/status?host=github&repo=github/learning-lab-components" alt="Dependabot Enablement" />
+  <a href="https://github.com/github/learning-lab-components/pulls?q=is%3Aopen+is%3Apr+label%3Adependencies"><img src="https://api.dependabot.com/badges/status?host=github&repo=github/learning-lab-components" alt="Dependabot Enablement" /></a>
   <a href="https://david-dm.org/github/learning-lab-components"><img src="https://img.shields.io/david/github/learning-lab-components.svg" alt="Dependencies Status" /></a>
   <a href="https://david-dm.org/github/learning-lab-components?type=dev"><img src="https://img.shields.io/david/dev/github/learning-lab-components.svg?label=devDependencies" alt="devDependencies Status" /></a>
 </p>


### PR DESCRIPTION
### Why?

If an image in a Markdown file does not have an explicit link around it, GitHub adds a link to the image itself. All of our badges except for the Dependabot badge have an explicit link wrapping, so adding this gives us more consistency between badges.

### What is being changed?

 - Add a more useful link around the Dependabot badge
 - Update a few link URLs to be absolute if they might fail based on how someone is viewing the `README.md`