### PR TITLE
Delete the Blank Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.md
+++ b/.github/ISSUE_TEMPLATE/blank.md
@@ -1,8 +1,0 @@
----
-name: Blank Issue
-about: Freeform issue for use about anything not covered by another template
-title: ''
-labels: ''
----
-
-


### PR DESCRIPTION
### Why?

When I added the "Blank Issue" issue template (in #36), I was copying that idea from another repo's issue templates. I also did not notice this handy link that achieves exactly the same thing:

<img width="830" alt="Screen Shot 2019-07-31 at 11 38 18 AM" src="https://user-images.githubusercontent.com/417751/62402201-3900b380-b54c-11e9-9dc6-31aace449430.png">

### What is being changed?

Removing the "Blank Issue" template.