### PR TITLE
Actions workflow: Release Management

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,6 +1,6 @@
-on: [push, pull_request]
-
 name: CI Build
+
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/release_management.yml
+++ b/.github/workflows/release_management.yml
@@ -1,0 +1,50 @@
+name: Release Management
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_draft_release:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: toolmantim/release-drafter@v5.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish_draft_release_on_version_bump:
+    needs: [update_draft_release]
+    runs-on: ubuntu-latest
+    steps:
+      # Does a checkout of your repository at the pushed commit SHA
+      - uses: actions/checkout@v1
+      # Checks for a version bump to publish an existing Draft Release
+      - id: github_release
+        uses: JamesMGreene/node-draft-releaser@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Show the Release URL, just for fun
+      - run: echo "Released at $RELEASE_URL"
+        env:
+          RELEASE_URL: ${{ steps.github_release.outputs.release_url }}
+
+  publish_package_to_gpr:
+    needs: [publish_draft_release_on_version_bump]
+    runs-on: ubuntu-latest
+    steps:
+      # Does a checkout of your repository at the pushed commit SHA
+      - uses: actions/checkout@v1
+      # Set up the local Node environment for the NPM CLI
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+          registry-url: 'https://npm.pkg.github.com'
+      # Install dependencies in case there are any publish-related scripts
+      - run: npm install
+      # Publish the new version to GPR
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Why?

Currently, publishing an NPM package to the GitHub Package Registry will automatically create a new Git Tag and GitHub Release for the new version unless they have already been published beforehand.

In combination with Release Drafter, which is continuously building up a Draft Release for the next release, the GPR publication ignores the Draft Release and creates its own, thereby requiring us to retroactively update the GPR-created Release's contents with the Draft Release's content. This is silly and annoying, so I made a new Action called `node-draft-releaser` to disrupt this process with automation. 🤖 🎉 

### What is being changed?

Adding a new workflow called "Release Management" containing 3 jobs [that run on a push to `master`], with dependencies on each other (`needs:`) and therefore run sequentially:
 1. Run the Release Drafter action to update the current Draft Release when new PRs are merged into `master`. 📝 
 2. Run the new Node Draft Releaser action to automatically publish the Draft Release when a new `version` is detected within `package.json` when pushed to `master`. 🏷 
 3. If that Release is published, then also publish the package to the GitHub Package Registry. 📦 
