### PR TITLE
Create schema test for assignRegistrant action

### DIFF
--- a/actions/assignRegistrant/schema.test.js
+++ b/actions/assignRegistrant/schema.test.js
@@ -1,0 +1,21 @@
+const Joi = require('@hapi/joi')
+const schema = require('./schema')
+
+describe('assignRegistrant Schema', () => {
+  it('Validates an Issue title without error', () => {
+    const validatedData = Joi.validate({ issue: 'String issue title' }, schema)
+    expect(validatedData.error).toBeNull()
+  })
+  it('Validates an Issue number without error', () => {
+    const validatedData = Joi.validate({ issue: 1 }, schema)
+    expect(validatedData.error).toBeNull()
+  })
+  it('Throws an errror if Issue is an object', () => {
+    const validatedData = Joi.validate({ issue: { number: 1 } }, schema)
+    expect(validatedData.error).not.toEqual(null)
+  })
+  it('Throws an error if Issue is an array', () => {
+    const validatedData = Joi.validate({ issue: ['Issue title', 2] }, schema)
+    expect(validatedData.error).not.toEqual(null)
+  })
+})


### PR DESCRIPTION
Hey @JamesMGreene 👋

Opening this draft to close #71, just wanted to make sure I was on the right track as I create these tests. Should be easy going if so.

### Why?

Due to breaking changes in the Joi API discovered in #69 / #70, this PR will add unit tests for each action schema in addition to the existing tests for each bot action.

Closes #71 

### What is being changed?

After reading up on the context, I think that having a `schema.test.js` file for each bot action is the right call. As @JamesMGreene said, this also means adding that to the action generator script. 

I think the tests themselves will be pretty straightforward, and most of the work will be thinking about realistic ways that an object could be malformed 