### PR TITLE
createStatus docs: Include possible "state" fields

### DIFF
--- a/actions/createStatus/README.md
+++ b/actions/createStatus/README.md
@@ -41,7 +41,7 @@ context: my-special-context
 
 | Title | Property | Description | Default | Required |
 | :---- | :--- | :---------- | :------ | :------- |
-| State | `state` | The state of the status to create. |  | ✔ |
+| State | `state` | The state of the status to create: `pending`, `failure`, or `success` |  | ✔ |
 | Error | `error` |  |  |  |
 | Pending | `pending` |  |  |  |
 | Failure | `failure` |  |  |  |

--- a/actions/createStatus/schema.js
+++ b/actions/createStatus/schema.js
@@ -16,7 +16,7 @@ module.exports = Joi.object({
       gate
     ])
     .meta({ label: 'State' })
-    .description('The state of the status to create.')
+    .description('The state of the status to create: `pending`, `failure`, or `success`')
     .required(),
   error: state.meta({ label: 'Error' }),
   pending: state.meta({ label: 'Pending' }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -7109,12 +7109,6 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
     "util.promisify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",


### PR DESCRIPTION
### Why?

With the `createStatus` action, `pending`, `failure`, and `success` can be their own field as well as the options for the `state` field. The current documentation is clear about those as their own fields, but unclear about what the possible options are for the `state` field. 

### What is being changed?

Documentation

---

If adding or updating an action, please verify that you have:
- ~~Added or updated tests, and verified they pass by executing `npm test`~~
- ~~Added or updated code comments, if applicable~~
- ~~Generated up-to-date documentation by executing `npm run doc`, if a schema was added or updated~~
