### PR TITLE
Fix createStatus when using an expected state

### DIFF
--- a/actions/createStatus/__snapshots__/index.test.js.snap
+++ b/actions/createStatus/__snapshots__/index.test.js.snap
@@ -42,3 +42,17 @@ Array [
   ],
 ]
 `;
+
+exports[`createStatus creates a status with expected state 1`] = `
+Array [
+  Array [
+    Object {
+      "context": "my-step",
+      "owner": "JasonEtco",
+      "repo": "example",
+      "sha": 123,
+      "state": "success",
+    },
+  ],
+]
+`;

--- a/actions/createStatus/index.js
+++ b/actions/createStatus/index.js
@@ -8,6 +8,8 @@ module.exports = async (context, opts) => {
     if (!realStates.includes(opts.state)) {
       const stateString = context.getValueFromContext(opts.state)
       state = stateString ? 'success' : 'failure'
+    } else {
+      state = opts.state
     }
   } else if (typeof opts.state === 'object') {
     const data = context.getValuesFromContext(opts.state)

--- a/actions/createStatus/index.test.js
+++ b/actions/createStatus/index.test.js
@@ -23,6 +23,12 @@ describe('createStatus', () => {
     expect(context.github.repos.createStatus.mock.calls).toMatchSnapshot()
   })
 
+  it('creates a status with expected state', async () => {
+    await createStatus(context, { state: 'success' })
+    expect(context.github.repos.createStatus).toHaveBeenCalled()
+    expect(context.github.repos.createStatus.mock.calls).toMatchSnapshot()
+  })
+
   it('creates a status with a gate-ish string', async () => {
     await createStatus(context, { state: '%payload.pull_request.body%' })
     expect(context.github.repos.createStatus).toHaveBeenCalled()


### PR DESCRIPTION
### Why?

There's a bug in `createStatus` that does't send through the expected state when it's specified by the author. The status is returned from GitHub with `state: pending`.

This was also brought up in https://github.com/github/learning-lab-components/pull/97#issuecomment-532998584. 

### What is being changed?

There was a missing `else` in the conditional where we parse through the parameters for a `createStatus` action.

❤️ thanks to @JasonEtco for helping me with this

---

If adding or updating an action, please verify that you have:
- [x] Added or updated tests, and verified they pass by executing `npm test`
- [ ] ~~Added or updated code comments, if applicable~~
- [ ] ~~Generated up-to-date documentation by executing `npm run doc`, if a schema was added or updated~~