### PR TITLE
Add validate-semver-release action to Release Management workflow

### DIFF
--- a/.github/workflows/release_management.yml
+++ b/.github/workflows/release_management.yml
@@ -30,9 +30,16 @@ jobs:
       - run: echo "Released at $RELEASE_URL"
         env:
           RELEASE_URL: ${{ steps.github_release.outputs.release_url }}
+          
+  validate_semver_release:
+    needs: [publish_draft_release_on_version_bump]
+    runs-on: ubuntu-latest
+    steps:
+      # Validate the Release follows Semantic Versioning rules
+      - uses: JasonEtco/validate-semver-release@master
 
   publish_package_to_gpr:
-    needs: [publish_draft_release_on_version_bump]
+    needs: [validate_semver_release]
     runs-on: ubuntu-latest
     steps:
       # Does a checkout of your repository at the pushed commit SHA

--- a/.github/workflows/release_management.yml
+++ b/.github/workflows/release_management.yml
@@ -35,6 +35,8 @@ jobs:
     needs: [publish_draft_release_on_version_bump]
     runs-on: ubuntu-latest
     steps:
+      # Does a checkout of your repository at the pushed commit SHA
+      - uses: actions/checkout@v1
       # Validate the Release follows Semantic Versioning rules
       - uses: JasonEtco/validate-semver-release@master
 


### PR DESCRIPTION
### Why?

Adds some extra verification to ensure that our release management workflow continues to be valid in the future even if we change the other pieces.

### What is being changed?

Adds another [ordered] Job to the Release Management workflow to validate the GitHub Release and the `"package.json"` file against a handful of semantic versioning rules.