### PR TITLE
Create new 'reopenIssue' bot action

### DIFF
--- a/actions/README.md
+++ b/actions/README.md
@@ -30,6 +30,7 @@ If you're interested in contributing to the evolution of these actions, we would
 - [mergePullRequest](./mergePullRequest)
 - [octokit](./octokit)
 - [removeBranchProtection](./removeBranchProtection)
+- [reopenIssue](./reopenIssue)
 - [requestReviewFromRegistrant](./requestReviewFromRegistrant)
 - [respond](./respond)
 - [updateBranchProtection](./updateBranchProtection)

--- a/actions/reopenIssue/README.md
+++ b/actions/reopenIssue/README.md
@@ -1,0 +1,38 @@
+<!--
+  /!\ WARNING /!\
+  This file's content is auto-generated, do NOT edit!
+  All changes will be undone.
+-->
+
+# `reopenIssue`
+
+Reopens a closed issue on GitHub. Will not negatively affect an open issue.
+
+## Examples
+
+Use the issue from the webhook payload:
+
+```yaml
+type: reopenIssue
+```
+
+Use the title of an issue:
+
+```yaml
+type: reopenIssue
+issue: Title of an issue
+```
+
+Use an issue number:
+
+```yaml
+type: reopenIssue
+issue: 4
+```
+
+## Options
+
+| Title | Property | Description | Default | Required |
+| :---- | :--- | :---------- | :------ | :------- |
+| Issue | `issue` | The number or title of the issue to reopen. |  |  |
+

--- a/actions/reopenIssue/__snapshots__/index.test.js.snap
+++ b/actions/reopenIssue/__snapshots__/index.test.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`reopenIssue reopens an issue with an issue number 1`] = `
+Array [
+  Array [
+    Object {
+      "number": 2,
+      "owner": "JasonEtco",
+      "repo": "example",
+      "state": "open",
+    },
+  ],
+]
+`;
+
+exports[`reopenIssue reopens an issue with an issue string 1`] = `
+Array [
+  Array [
+    Object {
+      "number": 2,
+      "owner": "JasonEtco",
+      "repo": "example",
+      "state": "open",
+    },
+  ],
+]
+`;
+
+exports[`reopenIssue reopens the issue from the webhook payload 1`] = `
+Array [
+  Array [
+    Object {
+      "number": 1,
+      "owner": "JasonEtco",
+      "repo": "example",
+      "state": "open",
+    },
+  ],
+]
+`;

--- a/actions/reopenIssue/index.js
+++ b/actions/reopenIssue/index.js
@@ -1,0 +1,26 @@
+const has = require('has')
+
+module.exports = async (context, opts) => {
+  let number
+  if (has(opts, 'issue')) {
+    if (typeof opts.issue === 'string') {
+      const { owner, repo } = context.repo()
+      const issues = await context.github.search.issues({
+        q: `is:issue in:title ${opts.issue} repo:${owner}/${repo}`
+      })
+      const issue = issues.data.items.find(i => i.title === opts.issue)
+      if (issue) number = issue.number
+    } else {
+      number = opts.issue
+    }
+
+    if (!number) throw new Error('Issue could not be found')
+  } else {
+    number = context.issue().number
+  }
+
+  return context.github.issues.update(context.repo({
+    number,
+    state: 'open'
+  }))
+}

--- a/actions/reopenIssue/index.test.js
+++ b/actions/reopenIssue/index.test.js
@@ -1,0 +1,51 @@
+const reopenIssue = require('./')
+const mockContext = require('../../tests/mockContext')
+
+describe('reopenIssue', () => {
+  let context
+
+  beforeEach(() => {
+    context = mockContext({
+      issue: {
+        number: 1
+      }
+    }, {
+      issues: {
+        update: jest.fn()
+      },
+      search: {
+        issues: jest.fn(() => Promise.resolve({
+          data: {
+            items: [{ title: 'My issue', number: 2 }]
+          }
+        }))
+      }
+    })
+  })
+
+  it('reopens the issue from the webhook payload', async () => {
+    await reopenIssue(context, {})
+    expect(context.github.issues.update).toHaveBeenCalled()
+    expect(context.github.issues.update.mock.calls).toMatchSnapshot()
+  })
+
+  it('reopens an issue with an issue string', async () => {
+    await reopenIssue(context, { issue: 'My issue' })
+    expect(context.github.issues.update).toHaveBeenCalled()
+    expect(context.github.issues.update.mock.calls).toMatchSnapshot()
+  })
+
+  it('reopens an issue with an issue number', async () => {
+    await reopenIssue(context, { issue: 2 })
+    expect(context.github.issues.update).toHaveBeenCalled()
+    expect(context.github.issues.update.mock.calls).toMatchSnapshot()
+  })
+
+  it('throws an error if the issue cannot be found', async () => {
+    try {
+      await reopenIssue(context, { issue: 'My issue' })
+    } catch (err) {
+      expect(err).toMatchSnapshot()
+    }
+  })
+})

--- a/actions/reopenIssue/schema.js
+++ b/actions/reopenIssue/schema.js
@@ -1,0 +1,20 @@
+const Joi = require('@hapi/joi')
+
+module.exports = Joi.object({
+  issue: Joi.alternatives().try(Joi.number(), Joi.string())
+    .meta({ label: 'Issue' })
+    .description('The number or title of the issue to reopen.')
+})
+  .description('Reopens a closed issue on GitHub. Will not negatively affect an open issue.')
+  .example([
+    {},
+    { context: 'Use the issue from the webhook payload:' }
+  ])
+  .example([
+    { issue: 'Title of an issue' },
+    { context: 'Use the title of an issue:' }
+  ])
+  .example([
+    { issue: 4 },
+    { context: 'Use an issue number:' }
+  ])

--- a/tests/actions/__snapshots__/index.test.js.snap
+++ b/tests/actions/__snapshots__/index.test.js.snap
@@ -24,6 +24,7 @@ Array [
   "mergePullRequest",
   "octokit",
   "removeBranchProtection",
+  "reopenIssue",
   "requestReviewFromRegistrant",
   "respond",
   "updateBranchProtection",


### PR DESCRIPTION
### Why?

Fulfills a need we encountered while authoring a new internal course while avoiding using the `octokit` action directly.

### What is being changed?

- Created a new `reopenIssue` bot action
  - It will reopen a closed issue/PR
  - It will not negatively affect an open issue/PR
  - It will fail for a non-existent issue

---

If adding or updating an action, please verify that you have:
- [x] Added or updated tests, and verified they pass by executing `npm test`
- [x] Added or updated code comments, if applicable
- [x] Generated up-to-date documentation by executing `npm run doc`, if a schema was added or updated
