### PR TITLE
Debug action

### DIFF
--- a/actions/README.md
+++ b/actions/README.md
@@ -18,6 +18,7 @@ If you're interested in contributing to the evolution of these actions, we would
 - [createPullRequestComment](./createPullRequestComment)
 - [createReview](./createReview)
 - [createStatus](./createStatus)
+- [debug](./debug)
 - [deleteBranch](./deleteBranch)
 - [findInTree](./findInTree)
 - [gate](./gate)

--- a/actions/debug/README.md
+++ b/actions/debug/README.md
@@ -1,0 +1,23 @@
+<!--
+  /!\ WARNING /!\
+  This file's content is auto-generated, do NOT edit!
+  All changes will be undone.
+-->
+
+# `debug`
+
+Creates a repository webhook to send debug information to smee.io. This is only enabled for "draft" versions of a course.
+
+## Examples
+
+Send repository payload information to smee.io:
+
+```yaml
+type: debug
+```
+
+## Options
+
+| Title | Property | Description | Default | Required |
+| :---- | :--- | :---------- | :------ | :------- |
+

--- a/actions/debug/README.md
+++ b/actions/debug/README.md
@@ -16,8 +16,4 @@ Send repository payload information to smee.io:
 type: debug
 ```
 
-## Options
-
-| Title | Property | Description | Default | Required |
-| :---- | :--- | :---------- | :------ | :------- |
 

--- a/actions/debug/__snapshots__/index.test.js.snap
+++ b/actions/debug/__snapshots__/index.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`debug sets the repo webhook for a draft course version 1`] = `
+Array [
+  Array [
+    Object {
+      "config": Object {
+        "content_type": "json",
+        "events": Array [
+          "push",
+          "issues",
+          "pull_request",
+          "issue_comment",
+        ],
+        "url": "https://smee.io/undefined-JasonEtco",
+      },
+      "name": "web",
+      "owner": "JasonEtco",
+      "repo": "example",
+    },
+  ],
+]
+`;

--- a/actions/debug/index.js
+++ b/actions/debug/index.js
@@ -1,0 +1,12 @@
+module.exports = async context => {
+  if (!context.courseVersion.draft) return
+  return context.github.repos.createHook(context.repo({
+    name: 'web',
+    config: {
+      url: `https://smee.io/${context.course.slug}-${context.user.login}`,
+      content_type: 'json',
+      // TODO: Fill in this list more intelligently
+      events: ['push', 'issues', 'pull_request', 'issue_comment']
+    }
+  }))
+}

--- a/actions/debug/index.js
+++ b/actions/debug/index.js
@@ -1,4 +1,4 @@
-module.exports = async context => {
+module.exports = async (context, opts) => {
   if (!context.courseVersion.draft) return
   const url = `https://smee.io/${context.course.slug}-${context.user.login}`
   await context.github.repos.createHook(context.repo({

--- a/actions/debug/index.js
+++ b/actions/debug/index.js
@@ -1,12 +1,15 @@
 module.exports = async context => {
   if (!context.courseVersion.draft) return
-  return context.github.repos.createHook(context.repo({
+  const url = `https://smee.io/${context.course.slug}-${context.user.login}`
+  await context.github.repos.createHook(context.repo({
     name: 'web',
     config: {
-      url: `https://smee.io/${context.course.slug}-${context.user.login}`,
+      url,
       content_type: 'json',
       // TODO: Fill in this list more intelligently
       events: ['push', 'issues', 'pull_request', 'issue_comment']
     }
   }))
+
+  // TODO: Post the URL somewhere, like an issue or in the repository description.
 }

--- a/actions/debug/index.test.js
+++ b/actions/debug/index.test.js
@@ -1,0 +1,27 @@
+const debug = require('./')
+const mockContext = require('../../tests/mockContext')
+
+describe('debug', () => {
+  let context
+
+  beforeEach(() => {
+    context = mockContext({}, {
+      repos: {
+        createHook: jest.fn()
+      }
+    })
+  })
+
+  it('sets the repo webhook for a draft course version', async () => {
+    context.courseVersion.draft = true
+    await debug(context, {})
+    expect(context.github.repos.addHook).toHaveBeenCalled()
+    expect(context.github.repos.addHook.mock.calls).toMatchSnapshot()
+  })
+
+  it('does not set the repo webhook for a non-draft course version', async () => {
+    context.courseVersion.draft = false
+    await debug(context, {})
+    expect(context.github.repos.addHook).not.toHaveBeenCalled()
+  })
+})

--- a/actions/debug/index.test.js
+++ b/actions/debug/index.test.js
@@ -15,13 +15,13 @@ describe('debug', () => {
   it('sets the repo webhook for a draft course version', async () => {
     context.courseVersion.draft = true
     await debug(context, {})
-    expect(context.github.repos.addHook).toHaveBeenCalled()
-    expect(context.github.repos.addHook.mock.calls).toMatchSnapshot()
+    expect(context.github.repos.createHook).toHaveBeenCalled()
+    expect(context.github.repos.createHook.mock.calls).toMatchSnapshot()
   })
 
   it('does not set the repo webhook for a non-draft course version', async () => {
     context.courseVersion.draft = false
     await debug(context, {})
-    expect(context.github.repos.addHook).not.toHaveBeenCalled()
+    expect(context.github.repos.createHook).not.toHaveBeenCalled()
   })
 })

--- a/actions/debug/schema.js
+++ b/actions/debug/schema.js
@@ -1,0 +1,8 @@
+const Joi = require('@hapi/joi')
+
+module.exports = Joi.object()
+  .description('Creates a repository webhook to send debug information to smee.io. This is only enabled for "draft" versions of a course.')
+  .example([
+    {},
+    { context: 'Send repository payload information to smee.io:' }
+  ])

--- a/script/generate-action-docs.js
+++ b/script/generate-action-docs.js
@@ -26,6 +26,7 @@ ${rows}
  * Convert a list of children properties into table rows.
  */
 function mapChildrenToRows (children) {
+  if (!children) return ''
   return Object.keys(children).reduce((prev, key) => {
     const opt = children[key]
     const cells = [

--- a/script/generate-action-docs.js
+++ b/script/generate-action-docs.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const path = require('path')
 const jsYaml = require('js-yaml')
 
-const template = ({ key, description, rows, examples }) => `<!--
+const template = ({ key, description, options, examples }) => `<!--
   /!\\ WARNING /!\\
   This file's content is auto-generated, do NOT edit!
   All changes will be undone.
@@ -15,12 +15,17 @@ ${description}
 
 ${examples}
 
-## Options
+${options}
+`
+
+function renderOptionsTable (rows) {
+  if (!rows) return ''
+  return `## Options
 
 | Title | Property | Description | Default | Required |
 | :---- | :--- | :---------- | :------ | :------- |
-${rows}
-`
+${rows}`
+}
 
 /**
  * Convert a list of children properties into table rows.
@@ -80,7 +85,7 @@ function generate (actionKey) {
     key: actionKey,
     title: (schema.metas && schema.metas[0] && schema.metas[0].label) || actionKey,
     description: schema.flags.description || '',
-    rows,
+    options: renderOptionsTable(rows),
     examples
   })
 }

--- a/tests/actions/__snapshots__/index.test.js.snap
+++ b/tests/actions/__snapshots__/index.test.js.snap
@@ -12,6 +12,7 @@ Array [
   "createPullRequestComment",
   "createReview",
   "createStatus",
+  "debug",
   "deleteBranch",
   "findInTree",
   "gate",

--- a/tests/mockContext.js
+++ b/tests/mockContext.js
@@ -113,6 +113,8 @@ module.exports = (payload, github) => {
   //
   context.fromFile = jest.fn().mockImplementation((name, data) => Promise.resolve(name))
   context.runActions = jest.fn()
+  context.course = {}
+  context.courseVersion = {}
 
   return context
 }


### PR DESCRIPTION
### Why?

When debugging a new course, its hard to know what events on GitHub are triggered and what those information your course can access. We want to do a lot more here, but one quick win is to create an action that posts webhook payloads to https://smee.io.

### What is being changed?

This PR creates a new action called `debug`. You would use it just by including this in your course's `before` block (or anywhere really):

```yaml
before:
  - type: debug
```

This sets a repository webhook using the course's title and the registrant's login:

```
smee.io/<course-slug>-<login>
```

### TODO:

* Fill out the list of events to listen for
* Post the created URL somewhere so that its discoverable; this might be in an issue, or in the repository description/URL. Would be nice if this were configurable, like an option for `post-to: issue | repo-url`.

---

If adding or updating an action, please verify that you have:
- [x] Added or updated tests, and verified they pass by executing `npm test`
- [x] Added or updated code comments, if applicable
- [x] Generated up-to-date documentation by executing `npm run doc`, if a schema was added or updated
