### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in the repo
 # unless a later match takes precedence.
-* @github/learning-engineering
+* @github/learning-engineering-reviewers


### PR DESCRIPTION
This sets the reviewer team to those regularly working on Learning Lab code rather than the full set of folks working in any capacity on Learning Lab.