### PR TITLE
add new action to enable GitHub Pages

### DIFF
--- a/actions/README.md
+++ b/actions/README.md
@@ -19,6 +19,7 @@ If you're interested in contributing to the evolution of these actions, we would
 - [createReview](./createReview)
 - [createStatus](./createStatus)
 - [deleteBranch](./deleteBranch)
+- [enablePages](./enablePages)
 - [findInTree](./findInTree)
 - [gate](./gate)
 - [getFileContents](./getFileContents)

--- a/actions/enablePages/README.md
+++ b/actions/enablePages/README.md
@@ -1,0 +1,40 @@
+<!--
+  /!\ WARNING /!\
+  This file's content is auto-generated, do NOT edit!
+  All changes will be undone.
+-->
+
+# `enablePages`
+
+Enable GitHub Pages on the learner's repository 
+
+## Examples
+
+Enable GitHub Pages on the `master` branch:
+
+```yaml
+type: enablePages
+```
+
+Enable GitHub Pages on the `gh-pages` branch:
+
+```yaml
+type: enablePages
+branch: gh-pages
+```
+
+Enable GitHub Pages on the `/docs` folder of the `master` branch:
+
+```yaml
+type: enablePages
+branch: master
+path: /docs
+```
+
+## Options
+
+| Title | Property | Description | Default | Required |
+| :---- | :--- | :---------- | :------ | :------- |
+| Branch | `branch` | The name of the branch to enable pages on. This defaults to `master`. | `master` |  |
+| Path | `path` | The name of the folder that contains the pages site. This defaults to `/`. | `/` |  |
+

--- a/actions/enablePages/index.js
+++ b/actions/enablePages/index.js
@@ -3,9 +3,7 @@ module.exports = async (context, opts) => {
   return context.github.request({
     method: 'POST',
     url: '/repos/:owner/:repo/pages',
-    mediaType: {
-      previews: ['switcheroo']
-    },
+    headers: { accept: 'application/vnd.github.switcheroo+json' },
     owner,
     repo,
     source: {

--- a/actions/enablePages/index.js
+++ b/actions/enablePages/index.js
@@ -1,0 +1,16 @@
+module.exports = async (context, opts) => {
+  const { owner, repo } = context.repo()
+  return context.github.request({
+    method: 'POST',
+    url: '/repos/:owner/:repo/pages',
+    mediaType: {
+      previews: ['switcheroo']
+    },
+    owner,
+    repo,
+    source: {
+      branch: opts.branch || 'master',
+      path: opts.path || '/'
+    }
+  })
+}

--- a/actions/enablePages/index.test.js
+++ b/actions/enablePages/index.test.js
@@ -11,7 +11,9 @@ describe('enablePages', () => {
     const { owner, repo } = context.repo()
     nocked = nock('https://api.github.com')
       .post(`/repos/${owner}/${repo}/pages`)
-      .reply(201, (url, opts) => ({ url, opts }))
+      .reply(201, function (url, opts) {
+        return { url, opts, headers: this.req.headers }
+      })
   })
 
   it('responds with a 201', async () => {
@@ -24,6 +26,7 @@ describe('enablePages', () => {
     const result = await enablePages(context, { branch: 'pizza' })
     expect(nocked.isDone()).toBe(true)
     expect(result.status).toBe(201)
+    expect(result.data.headers.accept).toEqual(['application/vnd.github.switcheroo+json'])
     expect(result.data.opts.source.branch).toBe('pizza')
     expect(result.data.opts.source.path).toBe('/')
   })

--- a/actions/enablePages/index.test.js
+++ b/actions/enablePages/index.test.js
@@ -1,0 +1,38 @@
+const nock = require('nock')
+const { GitHubAPI } = require('probot/lib/github')
+const enablePages = require('./')
+const mockContext = require('../../tests/mockContext')
+
+describe('enablePages', () => {
+  let context, nocked
+
+  beforeEach(() => {
+    context = mockContext({}, new GitHubAPI())
+    const { owner, repo } = context.repo()
+    nocked = nock('https://api.github.com')
+      .post(`/repos/${owner}/${repo}/pages`)
+      .reply(201, (url, opts) => ({ url, opts }))
+  })
+
+  it('responds with a 201', async () => {
+    const result = await enablePages(context, { })
+    expect(nocked.isDone()).toBe(true)
+    expect(result.status).toBe(201)
+  })
+
+  it('responds with the correct options when passed a branch', async () => {
+    const result = await enablePages(context, { branch: 'pizza' })
+    expect(nocked.isDone()).toBe(true)
+    expect(result.status).toBe(201)
+    expect(result.data.opts.source.branch).toBe('pizza')
+    expect(result.data.opts.source.path).toBe('/')
+  })
+
+  it('responds with the correct options when passed a branch and a path', async () => {
+    const result = await enablePages(context, { path: '/docs' })
+    expect(nocked.isDone()).toBe(true)
+    expect(result.status).toBe(201)
+    expect(result.data.opts.source.branch).toBe('master')
+    expect(result.data.opts.source.path).toBe('/docs')
+  })
+})

--- a/actions/enablePages/schema.js
+++ b/actions/enablePages/schema.js
@@ -1,0 +1,30 @@
+const Joi = require('@hapi/joi')
+
+module.exports = Joi.object({
+  branch: Joi.string()
+    .meta({ label: 'Branch' })
+    .description('The name of the branch to enable pages on. This defaults to `master`.')
+    .valid('master', 'gh-pages')
+    .default('master'),
+  path: Joi.string()
+    .meta({ label: 'Path' })
+    .description('The name of the folder that contains the pages site. This defaults to `/`.')
+    .valid('/', '/docs')
+    .default('/')
+})
+  .description('Enable GitHub Pages on the learner\'s repository ')
+  .example([
+    {},
+    { context: 'Enable GitHub Pages on the `master` branch:' }
+  ])
+  .example([
+    { branch: 'gh-pages' },
+    { context: 'Enable GitHub Pages on the `gh-pages` branch:' }
+  ])
+  .example([
+    {
+      branch: 'master',
+      path: '/docs'
+    },
+    { context: 'Enable GitHub Pages on the `/docs` folder of the `master` branch:' }
+  ])

--- a/tests/actions/__snapshots__/index.test.js.snap
+++ b/tests/actions/__snapshots__/index.test.js.snap
@@ -13,6 +13,7 @@ Array [
   "createReview",
   "createStatus",
   "deleteBranch",
+  "enablePages",
   "findInTree",
   "gate",
   "getFileContents",


### PR DESCRIPTION
### Why?

Learning Lab courses often use GitHub Pages as a way to give the user immediate feedback on their changes. However, the process of enabling pages requires navigation to settings and then back. A new endpoint was added to the GitHub API to enable pages on behalf of the user. This action takes advantage of this endpoint to improve the user experience.

### What is being changed?

Adds a new action to enable GitHub Pages on the learner's repository:

```
type: enablePages
```

By default, the action will enable pages on master, however it also accepts the optional branch of `gh-pages` or path of `/docs`.

:sparkles: and :tada: to @JasonEtco for walking me through this process!

---

If adding or updating an action, please verify that you have:
- [x] Added or updated tests, and verified they pass by executing `npm test`
- [x] Added or updated code comments, if applicable
- [x] Generated up-to-date documentation by executing `npm run doc`, if a schema was added or updated
