### PR TITLE
Add instruction to update snapshots

### DIFF
--- a/actions/README.md
+++ b/actions/README.md
@@ -66,6 +66,7 @@ Here's what you can do to help:
 8. Update the contents of the aforementioned files to bring your action to life!
   Be sure to execute `npm test` as you work to verify your syntax and test results.
 9. When you think your action is ready, execute `npm run doc` to regenerate the action-specific `actions/${actionName}/README.md`. Review the content to ensure it is to your liking.
-10. Commit all of your changes to the branch.
-11. Push that branch to your remote repository.
-12. Create a new [Pull Request](https://github.com/github/learning-lab-components/pulls) in this repository.
+10. Run `npm test -- -u` to update the snapshots.
+11. Commit all of your changes to the branch.
+12. Push that branch to your remote repository.
+13. Create a new [Pull Request](https://github.com/github/learning-lab-components/pulls) in this repository.


### PR DESCRIPTION
### Why?

While adding a new action today, I had some failing tests as a result of not updating the snapshots. 

### What is being changed?

This PR adds a note to the README to instruct users update the snapshots.

---

If adding or updating an action, please verify that you have:
- [x] Added or updated tests, and verified they pass by executing `npm test`
- [x] Added or updated code comments, if applicable
- [x] Generated up-to-date documentation by executing `npm run doc`, if a schema was added or updated
