### PR TITLE
Remove validate-semver-release action from Release Management workflow

### DIFF
--- a/.github/workflows/release_management.yml
+++ b/.github/workflows/release_management.yml
@@ -30,18 +30,9 @@ jobs:
       - run: echo "Released at $RELEASE_URL"
         env:
           RELEASE_URL: ${{ steps.github_release.outputs.release_url }}
-          
-  validate_semver_release:
-    needs: [publish_draft_release_on_version_bump]
-    runs-on: ubuntu-latest
-    steps:
-      # Does a checkout of your repository at the pushed commit SHA
-      - uses: actions/checkout@v1
-      # Validate the Release follows Semantic Versioning rules
-      - uses: JasonEtco/validate-semver-release@master
 
   publish_package_to_gpr:
-    needs: [validate_semver_release]
+    needs: [publish_draft_release_on_version_bump]
     runs-on: ubuntu-latest
     steps:
       # Does a checkout of your repository at the pushed commit SHA


### PR DESCRIPTION
### Why?

Upon the first release made after [adding the `validate-semver-release` Action in our Release Management workflow](#108), we now see/realize that the Action was created specifically to execute on a `release` event.

Due to the limitation of the results of one workflow (i.e. creating a Release) made with the `GITHUB_TOKEN` not being allow to trigger another workflow for rough prevention of infinite loops, we are currently attempting to use this Action on a `push` event instead.

Our misuse is currently [causing our Release Management workflow to fail](https://github.com/github/learning-lab-components/runs/519675150):

![image](https://user-images.githubusercontent.com/417751/77089564-fa811180-69d3-11ea-8892-05452bfa8cc9.png)

![image](https://user-images.githubusercontent.com/417751/77089760-3ae08f80-69d4-11ea-8cb6-40174627dc7f.png)

### What is being changed?

At least for now, we need to remove the use of the `validate-semver-release` Action. 😢 