### PR TITLE
Allow labels option for createIssue

### DIFF
--- a/actions/createIssue/README.md
+++ b/actions/createIssue/README.md
@@ -25,5 +25,6 @@ comments:
 | Title | `title` | The title of the issue to be created |  | ✔ |
 | Body | `body` | The body of the issue to be generated - this should be a markdown response file name. |  | ✔ |
 | Comments | `comments` | A list of response files that will be posted to the issue as comments upon creation. |  |  |
+| Labels | `labels` | A list of labels that will be applied to the issue. |  |  |
 | Data | `data` | An object of data that will be used in the response template. This can include values from the webhook payload, information about the user, or values returned from previous actions in the same step. |  |  |
 

--- a/actions/createIssue/__snapshots__/index.test.js.snap
+++ b/actions/createIssue/__snapshots__/index.test.js.snap
@@ -5,6 +5,7 @@ Array [
   Array [
     Object {
       "body": "a-body.md",
+      "labels": undefined,
       "owner": "JasonEtco",
       "repo": "example",
       "title": "My issue",
@@ -74,6 +75,7 @@ Array [
     Object {
       "body": "a-body.md",
       "labels": Array [
+        "feature request",
         "bug",
       ],
       "owner": "JasonEtco",

--- a/actions/createIssue/__snapshots__/index.test.js.snap
+++ b/actions/createIssue/__snapshots__/index.test.js.snap
@@ -67,3 +67,19 @@ Array [
   ],
 ]
 `;
+
+exports[`createIssue opens an issue with labels 1`] = `
+Array [
+  Array [
+    Object {
+      "body": "a-body.md",
+      "labels": Array [
+        "bug",
+      ],
+      "owner": "JasonEtco",
+      "repo": "example",
+      "title": "My issue",
+    },
+  ],
+]
+`;

--- a/actions/createIssue/index.js
+++ b/actions/createIssue/index.js
@@ -1,19 +1,11 @@
 const has = require('has')
 
 module.exports = async (context, opts) => {
-  let issue
-  if (has(opts, 'labels')) {
-    issue = await context.github.issues.create(context.repo({
-      title: opts.title,
-      body: await context.fromFile(opts.body, opts.data),
-      labels: opts.labels
-    }))
-  } else {
-    issue = await context.github.issues.create(context.repo({
-      title: opts.title,
-      body: await context.fromFile(opts.body, opts.data)
-    }))
-  }
+  const issue = await context.github.issues.create(context.repo({
+    title: opts.title,
+    body: await context.fromFile(opts.body, opts.data),
+    labels: opts.labels
+  }))
 
   if (has(opts, 'comments')) {
     for (const comment of opts.comments) {

--- a/actions/createIssue/index.js
+++ b/actions/createIssue/index.js
@@ -1,10 +1,19 @@
 const has = require('has')
 
 module.exports = async (context, opts) => {
-  const issue = await context.github.issues.create(context.repo({
-    title: opts.title,
-    body: await context.fromFile(opts.body, opts.data)
-  }))
+  let issue
+  if (has(opts, 'labels')) {
+    issue = await context.github.issues.create(context.repo({
+      title: opts.title,
+      body: await context.fromFile(opts.body, opts.data),
+      labels: opts.labels
+    }))
+  } else {
+    issue = await context.github.issues.create(context.repo({
+      title: opts.title,
+      body: await context.fromFile(opts.body, opts.data)
+    }))
+  }
 
   if (has(opts, 'comments')) {
     for (const comment of opts.comments) {

--- a/actions/createIssue/index.test.js
+++ b/actions/createIssue/index.test.js
@@ -31,4 +31,10 @@ describe('createIssue', () => {
     // Ensures that data was passed
     expect(context.fromFile.mock.calls).toMatchSnapshot()
   })
+
+  it('opens an issue with labels', async () => {
+    await createIssue(context, { title: 'My issue', body: 'a-body.md', labels: ['bug'] })
+    expect(context.github.issues.create).toHaveBeenCalled()
+    expect(context.github.issues.create.mock.calls).toMatchSnapshot()
+  })
 })

--- a/actions/createIssue/index.test.js
+++ b/actions/createIssue/index.test.js
@@ -33,7 +33,7 @@ describe('createIssue', () => {
   })
 
   it('opens an issue with labels', async () => {
-    await createIssue(context, { title: 'My issue', body: 'a-body.md', labels: ['bug'] })
+    await createIssue(context, { title: 'My issue', body: 'a-body.md', labels: ['feature request', 'bug'] })
     expect(context.github.issues.create).toHaveBeenCalled()
     expect(context.github.issues.create.mock.calls).toMatchSnapshot()
   })

--- a/actions/createIssue/schema.js
+++ b/actions/createIssue/schema.js
@@ -14,6 +14,10 @@ module.exports = Joi.object({
     .meta({ label: 'Comments' })
     .description('A list of response files that will be posted to the issue as comments upon creation.')
     .items(Joi.string()),
+  labels: Joi.array()
+    .meta({ label: 'Labels' })
+    .description('The label or labels to apply to the issue.')
+    .items(Joi.string()),
   data
 })
   .description('Creates a new issue on GitHub.')

--- a/actions/createIssue/schema.js
+++ b/actions/createIssue/schema.js
@@ -16,7 +16,7 @@ module.exports = Joi.object({
     .items(Joi.string()),
   labels: Joi.array()
     .meta({ label: 'Labels' })
-    .description('The label or labels to apply to the issue.')
+    .description('A list of labels that will be applied to the issue.')
     .items(Joi.string()),
   data
 })


### PR DESCRIPTION
### Why?

We are currently unable to create an issue and supply labels. Actually, we don't have any way of applying labels. This just updates the createIssue action to allow this option.

We're currently doing this [with Octokit](https://github.com/githubtraining/write-github-script/blob/3396a674484501dd49d522d333af182930a6c59a/config.yml#L373-L387)

### What is being changed?

Adds a `labels` option (an array) to the `createIssue` action.

---

If adding or updating an action, please verify that you have:
- [ ] Added or updated tests, and verified they pass by executing `npm test`
- [ ] Added or updated code comments, if applicable
- [ ] Generated up-to-date documentation by executing `npm run doc`, if a schema was added or updated
