### PR TITLE
Fix enablePages preview header

### DIFF
--- a/actions/enablePages/index.js
+++ b/actions/enablePages/index.js
@@ -3,7 +3,7 @@ module.exports = async (context, opts) => {
   return context.github.request({
     method: 'POST',
     url: '/repos/:owner/:repo/pages',
-    headers: { accept: 'application/vnd.github.switcheroo+json' },
+    headers: { accept: 'application/vnd.github.switcheroo-preview+json' },
     owner,
     repo,
     source: {

--- a/actions/enablePages/index.test.js
+++ b/actions/enablePages/index.test.js
@@ -26,7 +26,7 @@ describe('enablePages', () => {
     const result = await enablePages(context, { branch: 'pizza' })
     expect(nocked.isDone()).toBe(true)
     expect(result.status).toBe(201)
-    expect(result.data.headers.accept).toEqual(['application/vnd.github.switcheroo+json'])
+    expect(result.data.headers.accept).toEqual(['application/vnd.github.switcheroo-preview+json'])
     expect(result.data.opts.source.branch).toBe('pizza')
     expect(result.data.opts.source.path).toBe('/')
   })


### PR DESCRIPTION
### Why?

Closes #156 

### What is being changed?

This fixes the preview header used in the `enablePages` action, according to the [API docs](https://developer.github.com/v3/repos/pages/#enable-a-pages-site).

---

If adding or updating an action, please verify that you have:
- [x] Added or updated tests, and verified they pass by executing `npm test`
- [x] Added or updated code comments, if applicable
- [x] Generated up-to-date documentation by executing `npm run doc`, if a schema was added or updated
