### PR TITLE
Use the default branch instead of hard-coding master

### DIFF
--- a/actions/createFile/README.md
+++ b/actions/createFile/README.md
@@ -47,7 +47,7 @@ new_name: .github/CODEOWNERS
 | Title | Property | Description | Default | Required |
 | :---- | :--- | :---------- | :------ | :------- |
 | File name | `filename` | The name of the file to create. This must be a file in the `responses` folder of your course repository. |  | ✔ |
-| Branch | `branch` | The branch on which to create the file. This defaults to `master`. | `master` |  |
+| Branch | `branch` | The branch on which to create the file. This will be the repo's default branch if none is provided. |  |  |
 | Message | `message` | The commit message for the commit that creates the file. |  |  |
 | New name | `new_name` | The name of the file to be created. This can include a path, like `example/file.md`. |  |  |
 | Data | `data` | An object of data that will be used in the response template. This can include values from the webhook payload, information about the user, or values returned from previous actions in the same step. |  |  |

--- a/actions/createFile/schema.js
+++ b/actions/createFile/schema.js
@@ -8,8 +8,7 @@ module.exports = Joi.object({
     .required(),
   branch: Joi.string()
     .meta({ label: 'Branch' })
-    .description('The branch on which to create the file. This defaults to `master`.')
-    .default('master'),
+    .description('The branch on which to create the file. This will be the repo\'s default branch if none is provided.'),
   message: Joi.string()
     .meta({ label: 'Message' })
     .description('The commit message for the commit that creates the file.'),

--- a/actions/createPullRequest/README.md
+++ b/actions/createPullRequest/README.md
@@ -47,7 +47,7 @@ base: not-master
 | Title | `title` | The title of the pull request. |  | ✔ |
 | Body | `body` | The body of the pull request. |  | ✔ |
 | Head branch | `head` | The head branch of the pull request. |  | ✔ |
-| Base branch | `base` | The base branch of the pull request. This defaults to `master`. | `master` |  |
+| Base branch | `base` | The base branch of the pull request. This will be the repo's default branch if none was provided. |  |  |
 | Comments | `comments` | A list of response files that will be posted to the issue as comments upon creation. |  |  |
 | Data | `data` | An object of data that will be used in the response template. This can include values from the webhook payload, information about the user, or values returned from previous actions in the same step. |  |  |
 

--- a/actions/createPullRequest/README.md
+++ b/actions/createPullRequest/README.md
@@ -37,7 +37,7 @@ type: createPullRequest
 title: Title of the Pull Request
 body: pull-request-body.md
 head: this-branch
-base: not-master
+base: not-default-branch
 ```
 
 ## Options

--- a/actions/createPullRequest/__snapshots__/index.test.js.snap
+++ b/actions/createPullRequest/__snapshots__/index.test.js.snap
@@ -4,7 +4,7 @@ exports[`createPullRequest opens a pull request 1`] = `
 Array [
   Array [
     Object {
-      "base": "master",
+      "base": "main",
       "body": "a-body.md",
       "head": "branch",
       "owner": "JasonEtco",

--- a/actions/createPullRequest/index.js
+++ b/actions/createPullRequest/index.js
@@ -1,10 +1,10 @@
 const has = require('has')
-
+const getDefaultBranch = require('../../helpers/get-default-branch')
 module.exports = async (context, opts) => {
   const pr = await context.github.pullRequests.create(context.repo({
     title: opts.title,
     head: opts.head,
-    base: opts.base || 'master',
+    base: opts.base || getDefaultBranch(context),
     body: await context.fromFile(opts.body, opts.data)
   }))
 

--- a/actions/createPullRequest/schema.js
+++ b/actions/createPullRequest/schema.js
@@ -48,7 +48,7 @@ module.exports = Joi.object({
       title: 'Title of the Pull Request',
       body: 'pull-request-body.md',
       head: 'this-branch',
-      base: 'not-master'
+      base: 'not-default-branch'
     },
     { context: 'Create a pull request to a specified `base` branch:' }
   ])

--- a/actions/createPullRequest/schema.js
+++ b/actions/createPullRequest/schema.js
@@ -16,8 +16,7 @@ module.exports = Joi.object({
     .required(),
   base: Joi.string()
     .meta({ label: 'Base branch' })
-    .description('The base branch of the pull request. This defaults to `master`.')
-    .default('master'),
+    .description('The base branch of the pull request. This will be the repo\'s default branch if none was provided.'),
   comments: Joi.array()
     .meta({ label: 'Comments' })
     .description('A list of response files that will be posted to the issue as comments upon creation.')

--- a/actions/enablePages/README.md
+++ b/actions/enablePages/README.md
@@ -10,7 +10,7 @@ Enable GitHub Pages on the learner's repository
 
 ## Examples
 
-Enable GitHub Pages on the `master` branch:
+Enable GitHub Pages on the `main` branch:
 
 ```yaml
 type: enablePages
@@ -27,7 +27,7 @@ Enable GitHub Pages on the `/docs` folder of the `master` branch:
 
 ```yaml
 type: enablePages
-branch: master
+branch: main
 path: /docs
 ```
 
@@ -35,6 +35,6 @@ path: /docs
 
 | Title | Property | Description | Default | Required |
 | :---- | :--- | :---------- | :------ | :------- |
-| Branch | `branch` | The name of the branch to enable pages on. This defaults to `master`. | `master` |  |
+| Branch | `branch` | The name of the branch to enable pages on. This will be the repo's default branch if none was provided. |  |  |
 | Path | `path` | The name of the folder that contains the pages site. This defaults to `/`. | `/` |  |
 

--- a/actions/enablePages/README.md
+++ b/actions/enablePages/README.md
@@ -10,7 +10,7 @@ Enable GitHub Pages on the learner's repository
 
 ## Examples
 
-Enable GitHub Pages on the `main` branch:
+Enable GitHub Pages on the default branch:
 
 ```yaml
 type: enablePages
@@ -23,7 +23,7 @@ type: enablePages
 branch: gh-pages
 ```
 
-Enable GitHub Pages on the `/docs` folder of the `master` branch:
+Enable GitHub Pages on the `/docs` folder of the `main` branch:
 
 ```yaml
 type: enablePages

--- a/actions/enablePages/index.js
+++ b/actions/enablePages/index.js
@@ -1,3 +1,5 @@
+const getDefaultBranch = require('../../helpers/get-default-branch')
+
 module.exports = async (context, opts) => {
   const { owner, repo } = context.repo()
   return context.github.request({
@@ -7,7 +9,7 @@ module.exports = async (context, opts) => {
     owner,
     repo,
     source: {
-      branch: opts.branch || 'master',
+      branch: opts.branch || getDefaultBranch(context),
       path: opts.path || '/'
     }
   })

--- a/actions/enablePages/index.test.js
+++ b/actions/enablePages/index.test.js
@@ -35,7 +35,7 @@ describe('enablePages', () => {
     const result = await enablePages(context, { path: '/docs' })
     expect(nocked.isDone()).toBe(true)
     expect(result.status).toBe(201)
-    expect(result.data.opts.source.branch).toBe('master')
+    expect(result.data.opts.source.branch).toBe('main')
     expect(result.data.opts.source.path).toBe('/docs')
   })
 })

--- a/actions/enablePages/schema.js
+++ b/actions/enablePages/schema.js
@@ -13,7 +13,7 @@ module.exports = Joi.object({
   .description('Enable GitHub Pages on the learner\'s repository ')
   .example([
     {},
-    { context: 'Enable GitHub Pages on the `main` branch:' }
+    { context: 'Enable GitHub Pages on the default branch:' }
   ])
   .example([
     { branch: 'gh-pages' },
@@ -24,5 +24,5 @@ module.exports = Joi.object({
       branch: 'main',
       path: '/docs'
     },
-    { context: 'Enable GitHub Pages on the `/docs` folder of the `master` branch:' }
+    { context: 'Enable GitHub Pages on the `/docs` folder of the `main` branch:' }
   ])

--- a/actions/enablePages/schema.js
+++ b/actions/enablePages/schema.js
@@ -3,9 +3,7 @@ const Joi = require('@hapi/joi')
 module.exports = Joi.object({
   branch: Joi.string()
     .meta({ label: 'Branch' })
-    .description('The name of the branch to enable pages on. This defaults to `master`.')
-    .valid('master', 'gh-pages')
-    .default('master'),
+    .description('The name of the branch to enable pages on. This will be the repo\'s default branch if none was provided.'),
   path: Joi.string()
     .meta({ label: 'Path' })
     .description('The name of the folder that contains the pages site. This defaults to `/`.')
@@ -15,7 +13,7 @@ module.exports = Joi.object({
   .description('Enable GitHub Pages on the learner\'s repository ')
   .example([
     {},
-    { context: 'Enable GitHub Pages on the `master` branch:' }
+    { context: 'Enable GitHub Pages on the `main` branch:' }
   ])
   .example([
     { branch: 'gh-pages' },
@@ -23,7 +21,7 @@ module.exports = Joi.object({
   ])
   .example([
     {
-      branch: 'master',
+      branch: 'main',
       path: '/docs'
     },
     { context: 'Enable GitHub Pages on the `/docs` folder of the `master` branch:' }

--- a/actions/getTree/README.md
+++ b/actions/getTree/README.md
@@ -6,7 +6,7 @@
 
 # `getTree`
 
-Gets a Git tree at either a given sha or the head of master
+Gets a Git tree at either a given sha or the head of the default branch
 
 ## Examples
 

--- a/actions/getTree/index.js
+++ b/actions/getTree/index.js
@@ -5,7 +5,7 @@ module.exports = async (context, opts) => {
   let sha
 
   if (!has(opts, 'sha')) {
-    // Get the current "master" reference, to get the current master's sha
+    // Get the current default branch reference, to get the current HEAD sha
     const shaRes = await context.github.gitdata.getRef(context.repo({
       ref: `heads/${getDefaultBranch(context)}`
     }))

--- a/actions/getTree/index.js
+++ b/actions/getTree/index.js
@@ -1,4 +1,5 @@
 const has = require('has')
+const getDefaultBranch = require('../../helpers/get-default-branch')
 
 module.exports = async (context, opts) => {
   let sha
@@ -6,7 +7,7 @@ module.exports = async (context, opts) => {
   if (!has(opts, 'sha')) {
     // Get the current "master" reference, to get the current master's sha
     const shaRes = await context.github.gitdata.getRef(context.repo({
-      ref: `heads/${context.payload.repository.default_branch || 'master'}`
+      ref: `heads/${getDefaultBranch(context)}`
     }))
     sha = shaRes.data.object.sha
   } else {

--- a/actions/getTree/schema.js
+++ b/actions/getTree/schema.js
@@ -9,7 +9,7 @@ module.exports = Joi.object({
     .description('Include sub-paths, not just the top level directory.')
     .default(false)
 })
-  .description('Gets a Git tree at either a given sha or the head of master')
+  .description('Gets a Git tree at either a given sha or the head of the default branch')
   .example([
     {},
     { context: 'Get the tree at the current SHA:' }

--- a/actions/mergeBranch/README.md
+++ b/actions/mergeBranch/README.md
@@ -10,7 +10,7 @@ Merges a branch into another branch
 
 ## Examples
 
-Merge `a-feature-branch` into the `master` branch:
+Merge `a-feature-branch` into the default branch:
 
 ```yaml
 type: mergeBranch
@@ -30,5 +30,5 @@ base: release-one
 | Title | Property | Description | Default | Required |
 | :---- | :--- | :---------- | :------ | :------- |
 | Head branch | `head` | The head branch to merge from. |  | ✔ |
-| Base branch | `base` | The base branch to merge into. This defaults to `master`. | `master` |  |
+| Base branch | `base` | The base branch to merge into. This will be the repo's default branch if none was provided. |  |  |
 

--- a/actions/mergeBranch/__snapshots__/index.test.js.snap
+++ b/actions/mergeBranch/__snapshots__/index.test.js.snap
@@ -13,7 +13,7 @@ Array [
 ]
 `;
 
-exports[`mergeBranch merges a branch into thhe default branch 1`] = `
+exports[`mergeBranch merges a branch into the default branch 1`] = `
 Array [
   Array [
     Object {

--- a/actions/mergeBranch/__snapshots__/index.test.js.snap
+++ b/actions/mergeBranch/__snapshots__/index.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`mergeBranch merges a branch into master 1`] = `
+exports[`mergeBranch merges a branch into the provided base 1`] = `
 Array [
   Array [
     Object {
-      "base": "master",
+      "base": "dev",
       "head": "branch",
       "owner": "JasonEtco",
       "repo": "example",
@@ -13,11 +13,11 @@ Array [
 ]
 `;
 
-exports[`mergeBranch merges a branch into the provided base 1`] = `
+exports[`mergeBranch merges a branch into thhe default branch 1`] = `
 Array [
   Array [
     Object {
-      "base": "dev",
+      "base": "main",
       "head": "branch",
       "owner": "JasonEtco",
       "repo": "example",

--- a/actions/mergeBranch/index.js
+++ b/actions/mergeBranch/index.js
@@ -1,6 +1,8 @@
+const getDefaultBranch = require('../../helpers/get-default-branch')
+
 module.exports = async (context, opts) => {
   return context.github.repos.merge(context.repo({
-    base: opts.base || 'master',
+    base: opts.base || getDefaultBranch(context),
     head: opts.head
   }))
 }

--- a/actions/mergeBranch/index.test.js
+++ b/actions/mergeBranch/index.test.js
@@ -12,7 +12,7 @@ describe('mergeBranch', () => {
     })
   })
 
-  it('merges a branch into thhe default branch', async () => {
+  it('merges a branch into the default branch', async () => {
     await mergeBranch(context, { head: 'branch' })
     expect(context.github.repos.merge).toHaveBeenCalled()
     expect(context.github.repos.merge.mock.calls).toMatchSnapshot()

--- a/actions/mergeBranch/index.test.js
+++ b/actions/mergeBranch/index.test.js
@@ -12,7 +12,7 @@ describe('mergeBranch', () => {
     })
   })
 
-  it('merges a branch into master', async () => {
+  it('merges a branch into thhe default branch', async () => {
     await mergeBranch(context, { head: 'branch' })
     expect(context.github.repos.merge).toHaveBeenCalled()
     expect(context.github.repos.merge.mock.calls).toMatchSnapshot()

--- a/actions/mergeBranch/schema.js
+++ b/actions/mergeBranch/schema.js
@@ -7,13 +7,12 @@ module.exports = Joi.object({
     .required(),
   base: Joi.string()
     .meta({ label: 'Base branch' })
-    .description('The base branch to merge into. This defaults to `master`.')
-    .default('master')
+    .description('The base branch to merge into. This will be the repo\'s default branch if none was provided.')
 })
   .description('Merges a branch into another branch')
   .example([
     { head: 'a-feature-branch' },
-    { context: 'Merge `a-feature-branch` into the `master` branch:' }
+    { context: 'Merge `a-feature-branch` into the default branch:' }
   ])
   .example([
     {

--- a/actions/removeBranchProtection/README.md
+++ b/actions/removeBranchProtection/README.md
@@ -10,7 +10,7 @@ Removes the branch protection on a branch in the course repository
 
 ## Examples
 
-Remove branch protection from the `master` branch:
+Remove branch protection from the default branch:
 
 ```yaml
 type: removeBranchProtection

--- a/actions/removeBranchProtection/README.md
+++ b/actions/removeBranchProtection/README.md
@@ -27,5 +27,5 @@ branch: my-protected-branch
 
 | Title | Property | Description | Default | Required |
 | :---- | :--- | :---------- | :------ | :------- |
-| Branch | `branch` | The name of the branch to remove protection from. This defaults to `master`. | `master` |  |
+| Branch | `branch` | The name of the branch to remove protection from. This will be the repo's default branch if none was provided. |  |  |
 

--- a/actions/removeBranchProtection/__snapshots__/index.test.js.snap
+++ b/actions/removeBranchProtection/__snapshots__/index.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`removeBranchProtection removes branch protection on master by default 1`] = `
+exports[`removeBranchProtection removes branch protection on \`main\` by default 1`] = `
 Array [
   Array [
     Object {
-      "branch": "master",
+      "branch": "main",
       "owner": "JasonEtco",
       "repo": "example",
     },

--- a/actions/removeBranchProtection/index.js
+++ b/actions/removeBranchProtection/index.js
@@ -1,5 +1,7 @@
+const getDefaultBranch = require('../../helpers/get-default-branch')
+
 module.exports = async (context, opts) => {
   return context.github.repos.removeBranchProtection(context.repo({
-    branch: opts.branch || 'master'
+    branch: opts.branch || getDefaultBranch(context)
   }))
 }

--- a/actions/removeBranchProtection/index.test.js
+++ b/actions/removeBranchProtection/index.test.js
@@ -10,7 +10,7 @@ describe('removeBranchProtection', () => {
     })
   })
 
-  it('removes branch protection on master by default', async () => {
+  it('removes branch protection on `main` by default', async () => {
     await removeBranchProtection(context, {})
     expect(context.github.repos.removeBranchProtection).toHaveBeenCalled()
     expect(context.github.repos.removeBranchProtection.mock.calls).toMatchSnapshot()

--- a/actions/removeBranchProtection/schema.js
+++ b/actions/removeBranchProtection/schema.js
@@ -8,7 +8,7 @@ module.exports = Joi.object({
   .description('Removes the branch protection on a branch in the course repository')
   .example([
     {},
-    { context: 'Remove branch protection from the `master` branch:' }
+    { context: 'Remove branch protection from the default branch:' }
   ])
   .example([
     { branch: 'my-protected-branch' },

--- a/actions/removeBranchProtection/schema.js
+++ b/actions/removeBranchProtection/schema.js
@@ -3,8 +3,7 @@ const Joi = require('@hapi/joi')
 module.exports = Joi.object({
   branch: Joi.string()
     .meta({ label: 'Branch' })
-    .description('The name of the branch to remove protection from. This defaults to `master`.')
-    .default('master')
+    .description('The name of the branch to remove protection from. This will be the repo\'s default branch if none was provided.')
 })
   .description('Removes the branch protection on a branch in the course repository')
   .example([

--- a/actions/updateBranchProtection/README.md
+++ b/actions/updateBranchProtection/README.md
@@ -10,7 +10,7 @@ Updates the branch protection on a branch in the course repository
 
 ## Examples
 
-Add branch protection to the `master` branch:
+Add branch protection to the default branch:
 
 ```yaml
 type: updateBranchProtection

--- a/actions/updateBranchProtection/README.md
+++ b/actions/updateBranchProtection/README.md
@@ -34,7 +34,7 @@ enforce_admins: false
 
 | Title | Property | Description | Default | Required |
 | :---- | :--- | :---------- | :------ | :------- |
-| Branch | `branch` | The name of the branch to update protection settings on. This defaults to `master`. | `master` |  |
+| Branch | `branch` | The name of the branch to update protection settings on. This will be the repo's default branch if none was provided. |  |  |
 | Enforce protection for admins | `enforce_admins` | If enabled, these protection settings will be enforced for repository admins. | `true` |  |
 | Required status checks | `required_status_checks` | A list of status checks that are required before a pull request can be merged into this branch. |  |  |
 | Required pull request reviews | `required_pull_request_reviews` |  |  |  |

--- a/actions/updateBranchProtection/__snapshots__/index.test.js.snap
+++ b/actions/updateBranchProtection/__snapshots__/index.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`updateBranchProtection updates branch protection on master by default 1`] = `
+exports[`updateBranchProtection updates branch protection on \`main\` by default 1`] = `
 Array [
   Array [
     Object {
-      "branch": "master",
+      "branch": "main",
       "enforce_admins": true,
       "owner": "JasonEtco",
       "repo": "example",

--- a/actions/updateBranchProtection/index.js
+++ b/actions/updateBranchProtection/index.js
@@ -1,6 +1,8 @@
+const getDefaultBranch = require('../../helpers/get-default-branch')
+
 module.exports = async (context, opts) => {
   return context.github.repos.updateBranchProtection(context.repo({
-    branch: opts.branch || 'master',
+    branch: opts.branch || getDefaultBranch(context),
     enforce_admins: opts.enforce_admins || true,
     required_status_checks: opts.required_status_checks || null,
     required_pull_request_reviews: opts.required_pull_request_reviews || {},

--- a/actions/updateBranchProtection/index.test.js
+++ b/actions/updateBranchProtection/index.test.js
@@ -12,7 +12,7 @@ describe('updateBranchProtection', () => {
     })
   })
 
-  it('updates branch protection on master by default', async () => {
+  it('updates branch protection on `main` by default', async () => {
     await updateBranchProtection(context, {})
     expect(context.github.repos.updateBranchProtection).toHaveBeenCalled()
     expect(context.github.repos.updateBranchProtection.mock.calls).toMatchSnapshot()

--- a/actions/updateBranchProtection/schema.js
+++ b/actions/updateBranchProtection/schema.js
@@ -3,8 +3,7 @@ const Joi = require('@hapi/joi')
 module.exports = Joi.object({
   branch: Joi.string()
     .meta({ label: 'Branch' })
-    .description('The name of the branch to update protection settings on. This defaults to `master`.')
-    .default('master'),
+    .description('The name of the branch to update protection settings on. This will be the repo\'s default branch if none was provided.'),
   enforce_admins: Joi.boolean()
     .meta({ label: 'Enforce protection for admins' })
     .description('If enabled, these protection settings will be enforced for repository admins.')

--- a/actions/updateBranchProtection/schema.js
+++ b/actions/updateBranchProtection/schema.js
@@ -27,7 +27,7 @@ module.exports = Joi.object({
   .description('Updates the branch protection on a branch in the course repository')
   .example([
     {},
-    { context: 'Add branch protection to the `master` branch:' }
+    { context: 'Add branch protection to the default branch:' }
   ])
   .example([
     { branch: 'my-protected-branch' },

--- a/helpers/get-default-branch.js
+++ b/helpers/get-default-branch.js
@@ -1,0 +1,3 @@
+module.exports = function getDefaultBranch (context) {
+  return context.payload.repository.default_branch
+}

--- a/tests/mockContext.js
+++ b/tests/mockContext.js
@@ -83,7 +83,11 @@ module.exports = (payload, github) => {
     {
       event: {
         payload: {
-          repository: { owner: { login: 'JasonEtco' }, name: 'example' },
+          repository: {
+            owner: { login: 'JasonEtco' },
+            name: 'example',
+            default_branch: 'main'
+          },
           ...payload
         }
       },


### PR DESCRIPTION
### Why?

Because of an internal work item to change the default name of the default branch on all new repositories. This code needs to be flexible around the default branch's name.

<!--
Adding "Closes #123" to a pull request description will automatically close the issue once the pull request is merged into the `master` branch.
-->

### What is being changed?

Every time we assume `master` is the default branch, we now check `context.payload.repository.default_branch` (via a `getDefaultBranch` helper). I've updated all the docs, snapshots and code comments!

---

If adding or updating an action, please verify that you have:
- [x] Added or updated tests, and verified they pass by executing `npm test`
- [x] Added or updated code comments, if applicable
- [x] Generated up-to-date documentation by executing `npm run doc`, if a schema was added or updated
