### PR TITLE
Update docs and CI to refer to 'main' as the default branch

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Here are a few things you can do that will increase the likelihood of your pull 
 
 ## Releasing a new version
 
-Project administrators have permissions to publish new releases to the GitHub Package Registry by following these steps from an up-to-date `master` branch:
+Project administrators have permissions to publish new releases to the GitHub Package Registry by following these steps from an up-to-date `main` branch:
 
 1. Bump the package version and create a commit by using one of the appropriate NPM commands:
     - `npm version major`
@@ -51,7 +51,7 @@ Once a new version of this module has been released as a package in the GitHub P
 
 In the GitHub Learning Lab codebase, a member of the GitHub Learning Lab team should:
 
-1. Create a new branch from `master`
+1. Create a new branch from the default branch
 2. Install the latest version by executing `npm install @github/learning-lab-components@latest`
 3. Verify that all tests still pass by executing `npm test`
 4. Test the specific changes made to the components since the previous version was consumed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 Link to an issue if it exists, or describe the motivation behind this change/addition.
 
 <!--
-Adding "Closes #123" to a pull request description will automatically close the issue once the pull request is merged into the `master` branch.
+Adding "Closes #123" to a pull request description will automatically close the issue once the pull request is merged into the `main` branch.
 -->
 
 ### What is being changed?

--- a/.github/workflows/release_management.yml
+++ b/.github/workflows/release_management.yml
@@ -4,13 +4,13 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - master
+      - main
 
 jobs:
   update_draft_release:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      # Drafts your next Release notes as Pull Requests are merged into the default branch
       - uses: toolmantim/release-drafter@v5.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/actions/README.md
+++ b/actions/README.md
@@ -47,7 +47,7 @@ Here's what you can do to help:
 2. Clone this repository.
 3. Inside of the repository's directory, install dependencies by executing `npm install` from a terminal.
 4. Inside of the repository's directory, verify the tests initially pass on your machine by executing `npm test` from a terminal.
-5. Create a new branch from `master`.
+5. Create a new branch from `main`.
 6. Decide on a camel-cased name for your new action, e.g. `createIssue`.
   Henceforth, we will refer to this value as `${actionName}`.
 7. Inside of the repository's directory, generate a new action by executing `npm run action:init` from a terminal.


### PR DESCRIPTION
### Why?

We recently renamed our default branch from `master` to `main` to have more inclusive language.

### What is being changed?

I renamed the `master` branch to `main`, updated the default branch setting, updated the branch protection settings, retargeted the open PRs, and deleted the `master` branch. _Finally,_ I created this PR to update our documentation and CI configuration to reflect that new branch name.